### PR TITLE
VideoTrack: Set border-radius to 15 for angular videos.

### DIFF
--- a/src/components/Localuser/LocalVideo.tsx
+++ b/src/components/Localuser/LocalVideo.tsx
@@ -3,11 +3,11 @@ import styled from 'styled-components';
 import { useConferenceStore, VideoTrack } from './../../store/ConferenceStore';
 
 const Video = styled.video`
-  width: 200px; 
+  width: 200px;
   height: 200px;
   object-position: 50% 50%;
   display: block;
-  border-radius: 100px;
+  border-radius: 10px;
   object-fit: cover;
   transform: scaleX(-1);
 `

--- a/src/components/Localuser/Localuser.tsx
+++ b/src/components/Localuser/Localuser.tsx
@@ -14,7 +14,7 @@ const Container = styled.div`
   height: ${panOptions.user.size.y}px;
   position: absolute;
   border: 4px solid #D9DBEB;
-  border-radius: 300px;
+  border-radius: 15px;
   cursor: default;
   &:active {
     cursor: default;

--- a/src/components/User/VideoTrack.tsx
+++ b/src/components/User/VideoTrack.tsx
@@ -11,7 +11,7 @@ const Video = styled.video`
   height: 200px;
   object-position: 50% 50%;
   display: block;
-  border-radius: 100px;
+  border-radius: 15px;
   object-fit: cover;
   transform: scaleX(-1);
 `


### PR DESCRIPTION
Now the users are displayed as tiles again. 